### PR TITLE
Add basic web interface for image upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+uploads

--- a/README.md
+++ b/README.md
@@ -15,3 +15,11 @@ npm start
 ```
 
 執行後會將 `DSC08101.jpg` 產生加上文字與邊框的 `output.jpg`。
+
+### 啟動網頁介面
+
+```bash
+npm run start:web
+```
+
+開啟瀏覽器至 `http://localhost:3000`，上傳欲處理的圖片即可下載加上邊框與文字的結果。

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "scripts": {
-    "start": "node src/index.js"
+    "start": "node src/index.js",
+    "start:web": "node src/server.js"
   },
   "dependencies": {
     "canvas": "^3.1.0",
-    "exif-parser": "^0.1.12"
+    "exif-parser": "^0.1.12",
+    "express": "^4.18.2",
+    "multer": "^1.4.5"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Photo Border</title>
+</head>
+<body>
+  <h1>Upload Photo</h1>
+  <form action="/upload" method="post" enctype="multipart/form-data">
+    <input type="file" name="image" accept="image/*" required>
+    <button type="submit">Process</button>
+  </form>
+</body>
+</html>
+

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const multer = require('multer');
+const path = require('path');
+const fs = require('fs').promises;
+const { addBorderAndText } = require('./addBorderAndText');
+
+const app = express();
+const upload = multer({ dest: 'uploads/' });
+
+app.use(express.static(path.join(__dirname, '../public')));
+
+app.post('/upload', upload.single('image'), async (req, res) => {
+  try {
+    const inputPath = req.file.path;
+    const outputPath = path.join('uploads', `output-${Date.now()}.jpg`);
+    await addBorderAndText({ imagePath: inputPath, outputPath });
+    res.download(outputPath, err => {
+      if (err) console.error(err);
+      fs.unlink(inputPath).catch(() => {});
+      // output file may be kept for debugging; optionally remove
+    });
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Processing failed');
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Server listening on http://localhost:${PORT}`));
+


### PR DESCRIPTION
## Summary
- enable web server with Express and Multer
- add simple HTML upload form
- document running the web UI
- ignore upload directory

## Testing
- `npm test` *(fails: missing script)*
- `node -c src/server.js`

------
https://chatgpt.com/codex/tasks/task_e_6864a53f265c832ca92d7c5255264747