### PR TITLE
Update multer version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,9 @@
     "": {
       "dependencies": {
         "canvas": "^3.1.0",
-        "exif-parser": "^0.1.12"
+        "exif-parser": "^0.1.12",
+        "express": "^4.18.2",
+        "multer": "^1.4.5-lts.1"
       }
     },
     "node_modules/base64-js": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
     "canvas": "^3.1.0",
     "exif-parser": "^0.1.12",
     "express": "^4.18.2",
-    "multer": "^1.4.5"
+    "multer": "^1.4.5-lts.1"
   }
 }


### PR DESCRIPTION
## Summary
- bump `multer` from `^1.4.5` to `^1.4.5-lts.1`
- update lock file root dependencies for `express` and `multer`

## Testing
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6864ac976e08832cb4bfd8824d623fdd