### PR TITLE
Add styled preview and async upload

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,13 +3,33 @@
 <head>
   <meta charset="UTF-8">
   <title>Photo Border</title>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <h1>Upload Photo</h1>
-  <form action="/upload" method="post" enctype="multipart/form-data">
-    <input type="file" name="image" accept="image/*" required>
-    <button type="submit">Process</button>
-  </form>
+  <div class="container">
+    <h1>Upload Photo</h1>
+    <form id="uploadForm" action="/upload" method="post" enctype="multipart/form-data">
+      <input type="file" name="image" accept="image/*" required>
+      <button type="submit">Process</button>
+    </form>
+    <img id="preview" alt="Processed preview" />
+  </div>
+  <script>
+    const form = document.getElementById('uploadForm');
+    const preview = document.getElementById('preview');
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const formData = new FormData(form);
+      const res = await fetch('/upload', {
+        method: 'POST',
+        body: formData
+      });
+      if(!res.ok) return alert('Processing failed');
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      preview.src = url;
+      preview.style.display = 'block';
+    });
+  </script>
 </body>
 </html>
-

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,25 @@
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f8f8f8;
+  margin: 0;
+  padding: 0;
+}
+
+.container {
+  max-width: 800px;
+  margin: 50px auto;
+  padding: 20px;
+  background: white;
+  text-align: center;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+form {
+  margin-top: 20px;
+}
+
+#preview {
+  display: none;
+  margin-top: 20px;
+  max-width: 100%;
+}

--- a/src/server.js
+++ b/src/server.js
@@ -14,10 +14,10 @@ app.post('/upload', upload.single('image'), async (req, res) => {
     const inputPath = req.file.path;
     const outputPath = path.join('uploads', `output-${Date.now()}.jpg`);
     await addBorderAndText({ imagePath: inputPath, outputPath });
-    res.download(outputPath, err => {
+    res.sendFile(path.resolve(outputPath), err => {
       if (err) console.error(err);
       fs.unlink(inputPath).catch(() => {});
-      // output file may be kept for debugging; optionally remove
+      fs.unlink(outputPath).catch(() => {});
     });
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
## Summary
- create `style.css` with simple layout rules
- update `index.html` to use fetch-based upload and show image preview
- return processed image via `sendFile`

## Testing
- `npm run start:web` *(fails: Cannot find module 'express')*
- `npm start` *(fails: Cannot find module 'canvas')*

------
https://chatgpt.com/codex/tasks/task_e_6864af0af0f0832cad54a5a27da602f6