### PR TITLE
Add drag and drop support for multiple uploads

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,16 +7,39 @@
 </head>
 <body>
   <h1>Upload Photo</h1>
+  <div id="drop-area">Drop images here or click to select</div>
   <form id="upload-form" class="upload-form">
-    <input type="file" id="image" name="images" accept="image/*" multiple required>
+    <input type="file" id="image" name="images" multiple accept="image/*" required>
     <button type="submit" class="submit-btn">Process</button>
   </form>
   <h2>Preview</h2>
   <div id="preview-container"></div>
   <script>
-    document.getElementById('upload-form').addEventListener('submit', async (e) => {
+    const form = document.getElementById('upload-form');
+    const input = document.getElementById('image');
+    const dropArea = document.getElementById('drop-area');
+
+    dropArea.addEventListener('click', () => input.click());
+    ['dragenter', 'dragover'].forEach(event => {
+      dropArea.addEventListener(event, e => {
+        e.preventDefault();
+        dropArea.classList.add('highlight');
+      });
+    });
+    ['dragleave', 'drop'].forEach(event => {
+      dropArea.addEventListener(event, e => {
+        e.preventDefault();
+        dropArea.classList.remove('highlight');
+      });
+    });
+    dropArea.addEventListener('drop', e => {
+      const dt = new DataTransfer();
+      Array.from(e.dataTransfer.files).forEach(f => dt.items.add(f));
+      input.files = dt.files;
+    });
+
+    form.addEventListener('submit', async (e) => {
       e.preventDefault();
-      const input = document.getElementById('image');
       if (input.files.length === 0) return;
       const formData = new FormData();
       Array.from(input.files).forEach(file => formData.append('images', file));
@@ -26,10 +49,19 @@
         const container = document.getElementById('preview-container');
         container.innerHTML = '';
         data.urls.forEach(url => {
+          const wrapper = document.createElement('div');
           const img = document.createElement('img');
           img.src = url;
           img.className = 'preview-img';
-          container.appendChild(img);
+          img.onload = () => (img.style.display = 'block');
+          const link = document.createElement('a');
+          link.href = url;
+          link.download = '';
+          link.textContent = 'Download';
+          link.className = 'download-btn';
+          wrapper.appendChild(img);
+          wrapper.appendChild(link);
+          container.appendChild(wrapper);
         });
       } else {
         alert('Processing failed');

--- a/public/styles.css
+++ b/public/styles.css
@@ -5,6 +5,18 @@ body {
   color: #333;
 }
 
+#drop-area {
+  border: 2px dashed #ccc;
+  padding: 20px;
+  margin: 20px auto;
+  max-width: 600px;
+  color: #888;
+}
+
+#drop-area.highlight {
+  border-color: #666;
+}
+
 .upload-form {
   margin: 20px auto;
 }


### PR DESCRIPTION
## Summary
- support dropping multiple images onto the new drop zone
- forward dropped files to the input element
- show preview images with download links
- style the drop zone

## Testing
- `npm run start:web`

------
https://chatgpt.com/codex/tasks/task_e_6864deb9b6c8832c93b2f1d05f47138b