### PR TITLE
Fix preview image width

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -45,8 +45,8 @@ body {
 
 .preview-img {
   margin-top: 20px;
-  max-width: 600px;
-  width: 100%;
+  width: auto;
+  max-width: 100%;
   height: auto;
   display: none;
   border: 1px solid #ccc;
@@ -57,6 +57,7 @@ body {
   margin-top: 20px;
   max-width: 600px;
   width: 100%;
+  box-sizing: content-box;
   display: inline-block;
   border: 1px solid #ccc;
   box-shadow: 0 2px 6px rgba(0,0,0,0.2);


### PR DESCRIPTION
## Summary
- adjust `.preview-img` CSS so the image width is not forced to 100%
- keep preview wrapper width stable using `box-sizing: content-box`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864f14d118c832c9dbc11a7d6ef3b10