### PR TITLE
Rewrite frontend with Vite React and Tailwind

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,17 @@ npm run start:web
 ### 下載所有處理後的圖片
 
 上傳並處理完多張照片後，可按下「Download All」按鈕一次取得 ZIP 檔。伺服器提供 `/download-zip` 路徑會將上一批處理的檔案打包後下載。
+
+### 使用 React 版前端
+
+本專案已改寫前端為使用 Vite、React 與 TailwindCSS。開發階段可在 `client/` 目錄啟動
+Vite 開發伺服器：
+
+```bash
+cd client
+npm install
+npm run dev
+```
+
+建置完成後的檔案會產生在 `client/dist`，執行 Express 伺服器時若 `NODE_ENV=production`
+即會提供這些靜態檔案。

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Photo Border</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "photo-border-client",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^4.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "tailwindcss": "^3.4.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0"
+  }
+}

--- a/client/postcss.config.js
+++ b/client/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,0 +1,122 @@
+import React, { useRef, useState } from 'react';
+
+export default function App() {
+  const inputRef = useRef();
+  const [files, setFiles] = useState([]);
+  const [urls, setUrls] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [highlight, setHighlight] = useState(false);
+
+  const handleFiles = fileList => {
+    setFiles(Array.from(fileList));
+  };
+
+  const handleDrop = e => {
+    e.preventDefault();
+    setHighlight(false);
+    handleFiles(e.dataTransfer.files);
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    if (!files.length) return;
+    setLoading(true);
+    setUrls([]);
+    try {
+      const formData = new FormData();
+      files.forEach(f => formData.append('images', f));
+      formData.append('topBorder', e.target.topBorder.value);
+      formData.append('bottomBorder', e.target.bottomBorder.value);
+      formData.append('leftBorder', e.target.leftBorder.value);
+      formData.append('rightBorder', e.target.rightBorder.value);
+      formData.append('borderColor', e.target.borderColor.value);
+      const res = await fetch('/upload', { method: 'POST', body: formData });
+      if (res.ok) {
+        const data = await res.json();
+        setUrls(data.urls);
+      } else {
+        alert('Processing failed');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-2xl font-bold mb-4">Upload Photo</h1>
+      <div
+        id="drop-area"
+        className={`border-2 border-dashed p-4 mb-4 cursor-pointer ${
+          highlight ? 'border-gray-600' : 'border-gray-300'
+        }`}
+        onClick={() => inputRef.current.click()}
+        onDragEnter={e => {
+          e.preventDefault();
+          setHighlight(true);
+        }}
+        onDragOver={e => e.preventDefault()}
+        onDragLeave={() => setHighlight(false)}
+        onDrop={handleDrop}
+      >
+        Drag and drop multiple images here or click to select them
+      </div>
+      <form onSubmit={handleSubmit} className="space-y-4" id="upload-form">
+        <input
+          type="file"
+          multiple
+          accept="image/*"
+          ref={inputRef}
+          onChange={e => handleFiles(e.target.files)}
+          className="hidden"
+          name="image"
+        />
+        <div className="flex flex-wrap justify-center gap-2" id="options">
+          <label className="flex items-center gap-1">
+            Top
+            <input type="number" name="topBorder" defaultValue="200" className="border p-1 w-20" />
+          </label>
+          <label className="flex items-center gap-1">
+            Bottom
+            <input type="number" name="bottomBorder" defaultValue="500" className="border p-1 w-20" />
+          </label>
+          <label className="flex items-center gap-1">
+            Left
+            <input type="number" name="leftBorder" defaultValue="200" className="border p-1 w-20" />
+          </label>
+          <label className="flex items-center gap-1">
+            Right
+            <input type="number" name="rightBorder" defaultValue="200" className="border p-1 w-20" />
+          </label>
+          <label className="flex items-center gap-1">
+            Color
+            <input type="color" name="borderColor" defaultValue="#ffffff" className="border p-1" />
+          </label>
+        </div>
+        <button type="submit" className="bg-green-600 text-white px-4 py-2 rounded shadow">
+          Process
+        </button>
+      </form>
+      {loading && <div className="font-bold mt-4 animate-pulse">Processing...</div>}
+      <div id="preview-container" className="flex flex-wrap justify-center gap-4 mt-4">
+        {urls.map(url => (
+          <div key={url} className="flex flex-col items-center max-w-xs">
+            <img src={url} className="mt-4 shadow" />
+            <a href={url} download className="bg-blue-500 text-white px-4 py-2 rounded mt-2 shadow">
+              Download
+            </a>
+          </div>
+        ))}
+      </div>
+      {urls.length > 0 && (
+        <button
+          id="download-all"
+          onClick={() => (window.location = '/download-zip')}
+          className="bg-blue-500 text-white px-4 py-2 rounded mt-4 shadow"
+        >
+          Download All
+        </button>
+      )}
+    </div>
+  );
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist'
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "scripts": {
     "start": "node src/index.js",
-    "start:web": "node src/server.js"
+    "start:web": "node src/server.js",
+    "start:prod": "NODE_ENV=production node src/server.js",
+    "build:client": "cd client && npm run build"
   },
   "dependencies": {
     "canvas": "^3.1.0",

--- a/src/server.js
+++ b/src/server.js
@@ -14,7 +14,12 @@ const app = express();
 const upload = multer({ dest: 'uploads/' });
 let processedFilePaths = [];
 
-app.use(express.static(path.join(__dirname, '../public')));
+if (process.env.NODE_ENV === 'production') {
+  const clientPath = path.join(__dirname, '../client/dist');
+  app.use(express.static(clientPath));
+} else {
+  app.use(express.static(path.join(__dirname, '../public')));
+}
 app.use('/uploads', express.static(path.join(__dirname, '../uploads')));
 
 app.post('/upload', upload.array('images'), async (req, res) => {
@@ -68,5 +73,10 @@ app.get('/download-zip', (req, res) => {
 });
 
 const PORT = process.env.PORT || 3000;
+if (process.env.NODE_ENV === 'production') {
+  app.get('*', (req, res) => {
+    res.sendFile(path.join(__dirname, '../client/dist/index.html'));
+  });
+}
 app.listen(PORT, () => console.log(`Server listening on http://localhost:${PORT}`));
 


### PR DESCRIPTION
## Summary
- add a `client` directory containing a Vite + React app using TailwindCSS
- configure the Express server to serve the built React files in production
- provide helper scripts to build the client and run in production
- document new front‑end setup in README

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6865d4c7ca6c832cba0ae31fbd61867b